### PR TITLE
Add _content in collections and some tests

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -8,6 +8,8 @@ const yaml = require('js-yaml')
 const bindAllClass = require('es6bindall')
 const bindAll = require('lodash.bindall')
 const { map, reduce, filter } = require('objectfn')
+const MarkdownIt = require('markdown-it')
+const md = new MarkdownIt()
 
 class SpikeCollections {
   constructor(opts) {
@@ -164,6 +166,14 @@ class SpikeCollections {
           _path: relativePath.replace(/(.*)?(\..+?$)/, `$1.html`),
           _collection: k
         })
+
+        // Add _content special vars
+        const mdExtensions = ['md', 'markdown', 'mdown'];
+        if (mdExtensions.indexOf(p.split('.').pop()) > -1) {
+          Object.assign(locals, {
+            _content: md.render(fmMatch[2]) || null
+          })
+        }
 
         // run the transform function to replace frontmatter if it exists
         const transformFn = this.collections[k].transform

--- a/test/fixtures/markdown_layouts_only_contains_content/_post_layout.html
+++ b/test/fixtures/markdown_layouts_only_contains_content/_post_layout.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html>
+  <head>
+    <title>{{ title }}</title>
+  </head>
+  <body>
+    <h1>{{ title }}</h1>
+    <div>{{{ _content }}}</div>
+  </body>
+</html>

--- a/test/fixtures/markdown_layouts_only_contains_content/index.html
+++ b/test/fixtures/markdown_layouts_only_contains_content/index.html
@@ -1,0 +1,1 @@
+<all-posts retext-skip>{{{ JSON.stringify(_collections) }}}</all-posts>

--- a/test/fixtures/markdown_layouts_only_contains_content/posts/another.html
+++ b/test/fixtures/markdown_layouts_only_contains_content/posts/another.html
@@ -1,0 +1,5 @@
+---
+title: "Me me"
+---
+
+Lorem **bold** text

--- a/test/fixtures/markdown_layouts_only_contains_content/posts/test.md
+++ b/test/fixtures/markdown_layouts_only_contains_content/posts/test.md
@@ -1,0 +1,5 @@
+---
+title: 'wow'
+---
+
+Here's some **markdown**, so great!

--- a/test/index.js
+++ b/test/index.js
@@ -7,6 +7,8 @@ const rimraf = require('rimraf')
 const Collections = require('..')
 const fixtures = path.join(__dirname, 'fixtures')
 const htmlStandards = require('reshape-standard')
+const MarkdownIt = require('markdown-it')
+const md = new MarkdownIt()
 
 test.cb('frontmatter loader', t => {
   const root = path.join(fixtures, 'frontmatter-loader')
@@ -204,6 +206,34 @@ test.cb('markdownLayouts option', t => {
     rimraf.sync(publicPath)
     t.end()
   })
+})
+
+test.cb('_content in collections of markdown extension', t => {
+  const root = path.join(fixtures, 'markdown_layouts_only_contains_content')
+  const locals = {}
+  const opts = {
+    addDataTo: locals,
+    collections: {
+      posts: {
+        files: 'posts/**',
+        markdownLayout: '_post_layout.html'
+      }
+    }
+  }
+
+  spikeCompile(t, root, locals, opts, () => {
+    const publicPath = path.join(root, 'public')
+    const index = fs.readFileSync(path.join(publicPath, 'index.html'), 'utf8')
+
+    t.is(
+      index,
+      '<all-posts>{"posts":[{"title":"Me me","_path":"posts/another.html","_collection":"posts"},{"title":"wow","_path":"posts/test.html","_collection":"posts","_content":"<p>Here’s some <strong>markdown</strong>, so great!</p>\\n"}]}</all-posts>\n'
+    )
+
+    rimraf.sync(publicPath)
+    t.end()
+  })
+
 })
 
 test.cb('Jekyll date format', t => {


### PR DESCRIPTION
Adds `_content` in collection only of markdown files. The `_content` as well is parsed via `markdown-it`. Thanks